### PR TITLE
Add support for multiple packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm install --save gatsby-plugin-stencil
 
 ## How to use
 
+**Note**: Make sure you you have added the [`dist-hydrate-script` as output target](https://stenciljs.com/docs/hydrate-app) to your Stencil library
+
 Add the plugin to your `gatsby-config.js`
 
 ```js
@@ -19,6 +21,7 @@ module.exports = {
       resolve: `gatsby-plugin-stencil`,
       options: {
         // The module of your components (required), eg "@ionic/core".
+        // Add multiple modules by using an array eg ["@ionic/core", "my-stencil-components"]
         module: "your-stencil-components-package",
 
         // Stencil renderToString options (optional): https://stenciljs.com/docs/hydrate-app#configuration-options


### PR DESCRIPTION
Sorry this PR is a bit bigger than anticipated. Here is a summary of my changes:

- Allow for multiple modules e.g. `['@ionic/core', 'my-components-package']`
- Add better error handling
- Async everything