### PR TITLE
Refactor to handle hyrdation for stencil packages with lots of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ module.exports = {
         renderToStringOptions: {
           prettyHtml: true,
         },
+        // Number of workers to spin up (optional). Will default to half the number of CPUs detected via os.cpus()
+        numberOfWorkers: 4,
+        // Number of files to pass to each worker (optional). Will default to 100
+        workerChunkSize: 100,
       },
     },
   ],

--- a/src/hydrateFiles.js
+++ b/src/hydrateFiles.js
@@ -1,0 +1,144 @@
+const { Worker } = require("worker_threads");
+const { performance } = require("perf_hooks");
+
+/**
+ * Creates worker_threads and returning a promise for each thread.
+ *
+ * Promises resolve based on worker completing successfully,
+ * or rejects with an error if failure.
+ *
+ * @param {*} data
+ * @returns
+ */
+const runWorker = (data, reporter) => {
+  return new Promise((resolve, reject) => {
+    //Create worker, passing in data
+    const worker = new Worker(`${__dirname}/hydrateWorker.js`, {
+      workerData: data,
+    });
+    worker.on("message", resolve);
+    worker.on("error", reject);
+    worker.on("exit", (code) => {
+      if (code !== 0) {
+        reporter.error(`Worker exited with an error ${code}`);
+        reject(new Error(`Worker stopped with exit code ${code}`));
+      } else {
+        // reporter.info("Worker completed.");
+        resolve;
+      }
+    });
+  });
+};
+
+/**
+ * Wrapper for runWorker.
+ *
+ * Based on numWorkers and files left to process it calls
+ * runWorker passing necessary workerData to create worker_threads.
+ *
+ * @param {*} files
+ * @param {*} numWorkers
+ * @param {*} pkg
+ * @param {*} renderToStringOptions
+ * @param {*} reporter
+ * @returns
+ */
+const createWorkers = async (
+  files,
+  numWorkers,
+  pkg,
+  renderToStringOptions,
+  reporter
+) => {
+  //divide work among workers
+  const batchSize = Math.floor(files.length / numWorkers);
+  const workerPromises = [];
+  for (var i = 0; i < numWorkers; i++) {
+    workerPromises.push(
+      runWorker(
+        {
+          files: files.slice(i * batchSize, (i + 1) * batchSize),
+          workerId: i + 1,
+          pkg,
+          renderToStringOptions,
+        },
+        reporter
+      )
+    );
+  }
+  reporter.info(`Spawned ${i} workers`);
+
+  return Promise.all(workerPromises);
+};
+
+/**
+ * Loops over all files passed in, sets up initial config and
+ * passes through hyrdate options and stencil pkg to the handlers.
+ *
+ * @param {*} files
+ * @param {*} pkg
+ * @param {*} reporter
+ * @param {*} config
+ */
+exports.hydrateFiles = async (files, pkg, reporter, config) => {
+  const os = require("os");
+  let numWorkers = os.cpus().length / 2;
+
+  if (config.numberOfWorkers) {
+    numWorkers = config.numberOfWorkers;
+  }
+
+  let chunkSize = numWorkers * 100;
+  if (config.workerChunkSize) {
+    chunkSize = numWorkers * config.workerChunkSize;
+  }
+
+  const renderToStringOptions = config.renderToStringOptions
+    ? config.renderToStringOptions
+    : {};
+
+  reporter.info(
+    `Using ${numWorkers} workers with a chunkSize of ${chunkSize / numWorkers}`
+  );
+
+  let leftToProcess = files.length;
+  let start = 0;
+  let end = 0;
+  let loop = 0;
+
+  let overallStartTime = performance.now();
+  //Whilst we still have files:
+  while (leftToProcess > 0) {
+    reporter.info(`Files still to process ${leftToProcess}`);
+    start = loop * chunkSize;
+    end = start + chunkSize;
+    if (end > files.length) {
+      end = start + leftToProcess;
+    }
+    let startTime = performance.now();
+    await createWorkers(
+      files.slice(start, end),
+      numWorkers,
+      pkg,
+      renderToStringOptions,
+      reporter
+    );
+    let endTime = performance.now();
+    reporter.info(
+      `Processing ${end - start} files took ${(
+        (endTime - startTime) /
+        1000
+      ).toFixed(2)}s`
+    );
+    leftToProcess = leftToProcess - (end - start);
+    loop++;
+  }
+  let overallEndTime = performance.now();
+
+  reporter.success(
+    `Processing ${files.length} files took ${(
+      (overallEndTime - overallStartTime) /
+      1000
+    ).toFixed(2)}s`
+  );
+};

--- a/src/hydrateWorker.js
+++ b/src/hydrateWorker.js
@@ -1,0 +1,80 @@
+const { workerData, parentPort } = require("worker_threads");
+const fs = require("fs");
+const util = require("util");
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+const { files, workerId, pkg, renderToStringOptions } = workerData;
+const hydrate = require(`${pkg}/hydrate`);
+
+/**
+ * Loops over files and awaits processing of each.
+ *
+ * @param {*} files
+ * @returns
+ */
+const chunkFiles = async (files) => {
+  let filesProcessed = 0;
+  for (var i = 0; i < files.length; i++) {
+    filesProcessed++;
+    await processFile(files[i]).catch((e) => console.error(e));
+  }
+  return filesProcessed;
+};
+
+/**
+ * Performs Stencil package's renderToString on file path passed in.
+ *
+ * @param {*} file
+ */
+const processFile = async (file) => {
+  const page = await readFile(file, "utf8");
+  const { html, diagnostics = [] } = await hydrate.renderToString(
+    page,
+    renderToStringOptions
+  );
+
+  diagnostics.forEach((diagnostic) =>
+    console.error(
+      `error pre-rendering file: ${file}. ${JSON.stringify(
+        diagnostic,
+        null,
+        "  "
+      )}`
+    )
+  );
+
+  if (html) {
+    await writeFile(file, html);
+  }
+};
+
+/**
+ * Loops over batch of files provided to this worker passing to handler that hyrdates
+ * @param {*} files
+ */
+const processFiles = async (files) => {
+  const chunkSize = 10;
+  let loop = 0;
+  let position = 0;
+  let filesProcessed = 0;
+  while (files.length > position) {
+    position = loop * chunkSize;
+    if (position + chunkSize > files.length) {
+      filesProcessed += await chunkFiles(files.slice(position, files.length));
+    } else {
+      filesProcessed += await chunkFiles(
+        files.slice(position, position + chunkSize)
+      );
+    }
+    loop++;
+  }
+
+  // const used = process.memoryUsage().heapUsed / 1024 / 1024;
+  // console.info(`${workerId} - Finished processing ${filesProcessed}. Mem used ${Math.round(used * 100) / 100} MB.`);
+  parentPort.postMessage({
+    //send message with the result back to the parent process
+    filesProcessed: filesProcessed,
+  });
+};
+
+processFiles(files);

--- a/src/hydrateWorker.js
+++ b/src/hydrateWorker.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const util = require("util");
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
-const { files, workerId, pkg, renderToStringOptions } = workerData;
+const { files, pkg, renderToStringOptions } = workerData;
 const hydrate = require(`${pkg}/hydrate`);
 
 /**


### PR DESCRIPTION
I was finding that when using this plugin I was quickly running out of memory as the number of pages for the gatsby site increased.

The approach with this refactor is to split the actual loading of file content out into worker threads and process the files in batches. 

This means that any memory consumed by loading the files into memory is retrieved when the worker thread finishes, rather than waiting for GC to occur in main process.

There are two new options added for the user to configure, which is the number of workers to employ and the batch size to provide, which should allow the plugin user to restrict to sensible limits for their build environment. Defaults for these are commented in the readme.md.